### PR TITLE
adds publishing to private artifactory

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,8 +25,11 @@ allprojects {
         google()
         mavenCentral()
     }
+
     if (findProperty("final") != "true") {
-        version = "$version-SNAPSHOT"
+        version = "$version-hinge-SNAPSHOT"
+    } else {
+        version = "$version-hinge"
     }
 }
 
@@ -34,9 +37,3 @@ subprojects {
     apply(plugin = "otel.spotless-conventions")
 }
 
-nexusPublishing.repositories {
-    sonatype {
-        username.set(System.getenv("SONATYPE_USER"))
-        password.set(System.getenv("SONATYPE_KEY"))
-    }
-}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,12 +25,6 @@ allprojects {
         google()
         mavenCentral()
     }
-
-    if (findProperty("final") != "true") {
-        version = "$version-hinge-SNAPSHOT"
-    } else {
-        version = "$version-hinge"
-    }
 }
 
 subprojects {

--- a/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
@@ -1,13 +1,10 @@
-import com.android.build.api.dsl.LibraryExtension
+import com.android.build.gradle.LibraryExtension
 
 plugins {
     id("maven-publish")
-    id("signing")
 }
 
-version = project.version.toString().replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
-
-val isARelease = System.getenv("CI") != null
+version = project.version
 
 val android = extensions.findByType(LibraryExtension::class.java)
 
@@ -15,65 +12,44 @@ val androidVariantToRelease = "release"
 if (android != null) {
     android.publishing {
         singleVariant(androidVariantToRelease) {
-
-            // Adding sources and javadoc artifacts only during a release.
-            if (isARelease) {
-                withJavadocJar()
-                withSourcesJar()
-            }
-        }
-    }
-} else {
-    extensions.configure(JavaPluginExtension::class.java) {
-        if (isARelease) {
             withJavadocJar()
             withSourcesJar()
         }
     }
+} else {
+    extensions.configure(JavaPluginExtension::class.java) {
+        withJavadocJar()
+        withSourcesJar()
+    }
 }
 
 afterEvaluate {
-    publishing.publications {
-        val maven = create<MavenPublication>("maven") {
-            artifactId = computeArtifactId()
-            if (android != null) {
-                from(components.findByName(androidVariantToRelease))
-            } else {
-                from(components.findByName("java"))
-            }
-            pom {
-                val repoUrl = "https://github.com/open-telemetry/opentelemetry-android"
-                name.set("OpenTelemetry Android")
-                description.set(project.description)
-                url.set(repoUrl)
-                licenses {
-                    license {
-                        name.set("The Apache Software License, Version 2.0")
-                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                    }
-                }
-                scm {
-                    val scmUrl = "scm:git:git@github.com:open-telemetry/opentelemetry-android.git"
-                    connection.set(scmUrl)
-                    developerConnection.set(scmUrl)
-                    url.set(repoUrl)
-                    tag.set("HEAD")
-                }
-                developers {
-                    developer {
-                        id.set("opentelemetry")
-                        name.set("OpenTelemetry")
-                        url.set("https://github.com/open-telemetry/community")
-                    }
+    publishing {
+        repositories {
+            maven {
+                name = "HingeJFrog"
+                url = uri("https://matchgroupcentral.jfrog.io/artifactory/hingeandroid-prod-gradle")
+                credentials {
+                    username = System.getenv("MGC_JFROG_USERNAME")
+                    password = System.getenv("MGC_JFROG_PASSWORD")
                 }
             }
         }
 
-        // Signing only during a release.
-        if (isARelease) {
-            signing {
-                useInMemoryPgpKeys(System.getenv("GPG_PRIVATE_KEY"), System.getenv("GPG_PASSWORD"))
-                sign(maven)
+        publications {
+            create<MavenPublication>("maven") {
+                artifactId = computeArtifactId()
+                if (android != null) {
+                    from(components.findByName(androidVariantToRelease))
+                } else {
+                    from(components.findByName("java"))
+                }
+
+                pom {
+                    name.set("OpenTelemetry Android (Hinge Fork)")
+                    description.set(project.description)
+                    // Removing unnecessary POM metadata for internal artifact
+                }
             }
         }
     }
@@ -82,15 +58,9 @@ afterEvaluate {
 fun computeArtifactId(): String {
     val path = project.path
     if (!path.contains("instrumentation")) {
-        // Return default artifacId for non auto-instrumentation publications.
         return project.name
     }
-
-    // Adding library name to its related auto-instrumentation subprojects.
-    // For example, prepending "okhttp-3.0-" to both the "library" and "agent" subprojects inside the "okhttp-3.0" folder.
     val match = Regex("[^:]+:[^:]+\$").find(path)
     val artifactId = match!!.value.replace(":", "-")
-
-    logger.debug("Using artifact id: '{}' for subproject: '{}'", artifactId, path)
     return artifactId
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ android.useAndroidX=true
 android.minSdk=21
 android.compileSdk=35
 version=0.9.0
-group=io.opentelemetry.android
+group=co.hinge.opentelemetry


### PR DESCRIPTION
With this PR im just updating the publishing script to point twards our jfrog. With this in the future we can run `./gradlew :core:publishMavenPublicationToHingeJFrogRepository` to publish to our jfrog. Ideally we wont need to do this much if at all.  